### PR TITLE
fix: Adjust default namespace

### DIFF
--- a/ColorCode.Core/ColorCode.Core.csproj
+++ b/ColorCode.Core/ColorCode.Core.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
 		<TargetFrameworks>netstandard1.4;netstandard2.0;xamarinios10;MonoAndroid90;xamarinmac20;uap10.0</TargetFrameworks>
-		<RootNamespace>ColorCode</RootNamespace>
+		<RootNamespace>ColorCode.Core</RootNamespace>
     <AssemblyName>ColorCode.Core</AssemblyName>
 		<PackageId>Uno.ColorCode.Core</PackageId>
 		<Title>Uno.ColorCode.Core</Title>


### PR DESCRIPTION
Fixes conflicts between generated resources in ColorCode.UWP and ColorCode.Core.